### PR TITLE
pkg/cwhub: simpler accessor methods

### DIFF
--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -156,13 +156,10 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		return false, false, fmt.Errorf("parsing api url: %w", err)
 	}
 
-	scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
-	if err != nil {
-		return false, false, fmt.Errorf("failed to get scenarios: %w", err)
-	}
+	itemsForAPI := hub.GetInstalledListForAPI()
 
-	if len(scenarios) == 0 {
-		return false, false, errors.New("no scenarios installed, abort")
+	if len(itemsForAPI) == 0 {
+		return false, false, errors.New("no scenarios or appsec-rules installed, abort")
 	}
 
 	passwd := strfmt.Password(password)
@@ -170,26 +167,14 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 	client, err := apiclient.NewClient(&apiclient.Config{
 		MachineID: login,
 		Password:  passwd,
-		Scenarios: scenarios,
+		Scenarios: itemsForAPI,
 		UserAgent: cwversion.UserAgent(),
 		URL:       apiURL,
 		//I don't believe papi is neede to check enrollement
 		//PapiURL:       papiURL,
 		VersionPrefix: "v3",
 		UpdateScenario: func() ([]string, error) {
-			l_scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
-			if err != nil {
-				return nil, err
-			}
-			appsecRules, err := hub.GetInstalledNamesByType(cwhub.APPSEC_RULES)
-			if err != nil {
-				return nil, err
-			}
-			ret := make([]string, 0, len(l_scenarios)+len(appsecRules))
-			ret = append(ret, l_scenarios...)
-			ret = append(ret, appsecRules...)
-
-			return ret, nil
+			return itemsForAPI, nil
 		},
 	})
 
@@ -202,7 +187,7 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 	t := models.WatcherAuthRequest{
 		MachineID: &login,
 		Password:  &pw,
-		Scenarios: scenarios,
+		Scenarios: itemsForAPI,
 	}
 
 	authResp, _, err := client.Auth.AuthenticateWatcher(context.Background(), t)

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -148,16 +148,11 @@ func (cli *cliHub) upgrade(ctx context.Context, force bool) error {
 	}
 
 	for _, itemType := range cwhub.ItemTypes {
-		items, err := hub.GetInstalledItemsByType(itemType)
-		if err != nil {
-			return err
-		}
-
 		updated := 0
 
 		log.Infof("Upgrading %s", itemType)
 
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(itemType, true) {
 			didUpdate, err := item.Upgrade(ctx, force)
 			if err != nil {
 				return err

--- a/cmd/crowdsec-cli/item_suggest.go
+++ b/cmd/crowdsec-cli/item_suggest.go
@@ -19,7 +19,7 @@ func suggestNearestMessage(hub *cwhub.Hub, itemType string, itemName string) str
 	score := 100
 	nearest := ""
 
-	for _, item := range hub.GetItemMap(itemType) {
+	for _, item := range hub.GetItemsByType(itemType, false) {
 		d := levenshtein.Distance(itemName, item.Name, nil)
 		if d < score {
 			score = d
@@ -44,7 +44,7 @@ func compAllItems(itemType string, args []string, toComplete string, cfg configG
 
 	comp := make([]string, 0)
 
-	for _, item := range hub.GetItemMap(itemType) {
+	for _, item := range hub.GetItemsByType(itemType, false) {
 		if !slices.Contains(args, item.Name) && strings.Contains(item.Name, toComplete) {
 			comp = append(comp, item.Name)
 		}
@@ -61,22 +61,14 @@ func compInstalledItems(itemType string, args []string, toComplete string, cfg c
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 
-	items, err := hub.GetInstalledNamesByType(itemType)
-	if err != nil {
-		cobra.CompDebugln(fmt.Sprintf("list installed %s err: %s", itemType, err), true)
-		return nil, cobra.ShellCompDirectiveDefault
-	}
+	items := hub.GetInstalledByType(itemType, true)
 
 	comp := make([]string, 0)
 
-	if toComplete != "" {
-		for _, item := range items {
-			if strings.Contains(item, toComplete) {
-				comp = append(comp, item)
-			}
+	for _, item := range items {
+		if strings.Contains(item.Name, toComplete) {
+			comp = append(comp, item.Name)
 		}
-	} else {
-		comp = items
 	}
 
 	cobra.CompDebugln(fmt.Sprintf("%s: %+v", itemType, comp), true)

--- a/cmd/crowdsec-cli/itemcli.go
+++ b/cmd/crowdsec-cli/itemcli.go
@@ -147,19 +147,14 @@ func (cli cliItem) remove(args []string, purge bool, force bool, all bool) error
 	}
 
 	if all {
-		getter := hub.GetInstalledItemsByType
+		itemGetter := hub.GetInstalledByType
 		if purge {
-			getter = hub.GetItemsByType
-		}
-
-		items, err := getter(cli.name)
-		if err != nil {
-			return err
+			itemGetter = hub.GetItemsByType
 		}
 
 		removed := 0
 
-		for _, item := range items {
+		for _, item := range itemGetter(cli.name, true) {
 			didRemove, err := item.Remove(purge, force)
 			if err != nil {
 				return err
@@ -262,14 +257,9 @@ func (cli cliItem) upgrade(ctx context.Context, args []string, force bool, all b
 	}
 
 	if all {
-		items, err := hub.GetInstalledItemsByType(cli.name)
-		if err != nil {
-			return err
-		}
-
 		updated := 0
 
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(cli.name, true) {
 			didUpdate, err := item.Upgrade(ctx, force)
 			if err != nil {
 				return err

--- a/cmd/crowdsec-cli/items.go
+++ b/cmd/crowdsec-cli/items.go
@@ -17,7 +17,12 @@ import (
 
 // selectItems returns a slice of items of a given type, selected by name and sorted by case-insensitive name
 func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly bool) ([]*cwhub.Item, error) {
-	itemNames := hub.GetNamesByType(itemType)
+	allItems := hub.GetItemsByType(itemType, true)
+
+	itemNames := make([]string, len(allItems))
+	for idx, item := range allItems {
+		itemNames[idx] = item.Name
+	}
 
 	notExist := []string{}
 
@@ -38,7 +43,7 @@ func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly b
 		installedOnly = false
 	}
 
-	items := make([]*cwhub.Item, 0, len(itemNames))
+	wantedItems := make([]*cwhub.Item, 0, len(itemNames))
 
 	for _, itemName := range itemNames {
 		item := hub.GetItem(itemType, itemName)
@@ -46,12 +51,10 @@ func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly b
 			continue
 		}
 
-		items = append(items, item)
+		wantedItems = append(wantedItems, item)
 	}
 
-	cwhub.SortItemSlice(items)
-
-	return items, nil
+	return wantedItems, nil
 }
 
 func listItems(out io.Writer, wantColor string, itemTypes []string, items map[string][]*cwhub.Item, omitIfEmpty bool, output string) error {

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -45,11 +45,6 @@ func QueryLAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		return fmt.Errorf("parsing api url: %w", err)
 	}
 
-	scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
-	if err != nil {
-		return fmt.Errorf("failed to get scenarios: %w", err)
-	}
-
 	client, err := apiclient.NewDefaultClient(apiURL,
 		LAPIURLPrefix,
 		cwversion.UserAgent(),
@@ -60,10 +55,12 @@ func QueryLAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 
 	pw := strfmt.Password(password)
 
+	itemsForAPI := hub.GetInstalledListForAPI()
+
 	t := models.WatcherAuthRequest{
 		MachineID: &login,
 		Password:  &pw,
-		Scenarios: scenarios,
+		Scenarios: itemsForAPI,
 	}
 
 	_, _, err = client.Auth.AuthenticateWatcher(context.Background(), t)

--- a/cmd/crowdsec/lpmetrics.go
+++ b/cmd/crowdsec/lpmetrics.go
@@ -46,10 +46,8 @@ func getHubState(hub *cwhub.Hub) models.HubItems {
 
 	for _, itemType := range cwhub.ItemTypes {
 		ret[itemType] = []models.HubItem{}
-		items, _ := hub.GetInstalledItemsByType(itemType)
-		cwhub.SortItemSlice(items)
 
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(itemType, true) {
 			status := "official"
 			if item.State.IsLocal() {
 				status = "custom"

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -91,10 +91,8 @@ func LoadBuckets(cConfig *csconfig.Config, hub *cwhub.Hub) error {
 		files []string
 	)
 
-	for _, hubScenarioItem := range hub.GetItemMap(cwhub.SCENARIOS) {
-		if hubScenarioItem.State.Installed {
-			files = append(files, hubScenarioItem.State.LocalPath)
-		}
+	for _, hubScenarioItem := range hub.GetInstalledByType(cwhub.SCENARIOS, false) {
+		files = append(files, hubScenarioItem.State.LocalPath)
 	}
 
 	buckets = leakybucket.NewBuckets()

--- a/pkg/alertcontext/config.go
+++ b/pkg/alertcontext/config.go
@@ -104,14 +104,9 @@ func LoadConsoleContext(c *csconfig.Config, hub *cwhub.Hub) error {
 	c.Crowdsec.ContextToSend = make(map[string][]string, 0)
 
 	if hub != nil {
-		items, err := hub.GetInstalledItemsByType(cwhub.CONTEXTS)
-		if err != nil {
-			return err
-		}
-
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(cwhub.CONTEXTS, true) {
 			// context in item files goes under the key 'context'
-			if err = addContextFromItem(c.Crowdsec.ContextToSend, item); err != nil {
+			if err := addContextFromItem(c.Crowdsec.ContextToSend, item); err != nil {
 				return err
 			}
 		}

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -177,19 +177,13 @@ func (wc *AppsecConfig) LoadByPath(file string) error {
 }
 
 func (wc *AppsecConfig) Load(configName string) error {
-	appsecConfigs := hub.GetItemMap(cwhub.APPSEC_CONFIGS)
+	item := hub.GetItem(cwhub.APPSEC_CONFIGS, configName)
 
-	for _, hubAppsecConfigItem := range appsecConfigs {
-		if !hubAppsecConfigItem.State.Installed {
-			continue
-		}
-		if hubAppsecConfigItem.Name != configName {
-			continue
-		}
-		wc.Logger.Infof("loading %s", hubAppsecConfigItem.State.LocalPath)
-		err := wc.LoadByPath(hubAppsecConfigItem.State.LocalPath)
+	if item != nil && item.State.Installed {
+		wc.Logger.Infof("loading %s", item.State.LocalPath)
+		err := wc.LoadByPath(item.State.LocalPath)
 		if err != nil {
-			return fmt.Errorf("unable to load appsec-config %s : %s", hubAppsecConfigItem.State.LocalPath, err)
+			return fmt.Errorf("unable to load appsec-config %s : %s", item.State.LocalPath, err)
 		}
 		return nil
 	}

--- a/pkg/appsec/loader.go
+++ b/pkg/appsec/loader.go
@@ -17,11 +17,7 @@ func LoadAppsecRules(hubInstance *cwhub.Hub) error {
 	hub = hubInstance
 	appsecRules = make(map[string]AppsecCollectionConfig)
 
-	for _, hubAppsecRuleItem := range hub.GetItemMap(cwhub.APPSEC_RULES) {
-		if !hubAppsecRuleItem.State.Installed {
-			continue
-		}
-
+	for _, hubAppsecRuleItem := range hub.GetInstalledByType(cwhub.APPSEC_RULES, false) {
 		content, err := os.ReadFile(hubAppsecRuleItem.State.LocalPath)
 		if err != nil {
 			log.Warnf("unable to read file %s : %s", hubAppsecRuleItem.State.LocalPath, err)

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -44,11 +43,4 @@ func safePath(dir, filePath string) (string, error) {
 	}
 
 	return absFilePath, nil
-}
-
-// SortItemSlice sorts a slice of items by name, case insensitive.
-func SortItemSlice(items []*Item) {
-	sort.Slice(items, func(i, j int) bool {
-		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
-	})
 }

--- a/pkg/cwhub/doc.go
+++ b/pkg/cwhub/doc.go
@@ -74,7 +74,7 @@
 // Now you can use the hub object to access the existing items:
 //
 //	// list all the parsers
-//	for _, parser := range hub.GetItemMap(cwhub.PARSERS) {
+//	for _, parser := range hub.GetItemsByType(cwhub.PARSERS, false) {
 //		fmt.Printf("parser: %s\n", parser.Name)
 //	}
 //

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -223,39 +223,30 @@ func (t *HubTestItem) InstallHub() error {
 	ctx := context.Background()
 
 	// install data for parsers if needed
-	ret := hub.GetItemMap(cwhub.PARSERS)
-	for parserName, item := range ret {
-		if item.State.Installed {
-			if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
-				return fmt.Errorf("unable to download data for parser '%s': %+v", parserName, err)
-			}
-
-			log.Debugf("parser '%s' installed successfully in runtime environment", parserName)
+	for _, item := range hub.GetInstalledByType(cwhub.PARSERS, true) {
+		if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
+			return fmt.Errorf("unable to download data for parser '%s': %+v", item.Name, err)
 		}
+
+		log.Debugf("parser '%s' installed successfully in runtime environment", item.Name)
 	}
 
 	// install data for scenarios if needed
-	ret = hub.GetItemMap(cwhub.SCENARIOS)
-	for scenarioName, item := range ret {
-		if item.State.Installed {
-			if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
-				return fmt.Errorf("unable to download data for parser '%s': %+v", scenarioName, err)
-			}
-
-			log.Debugf("scenario '%s' installed successfully in runtime environment", scenarioName)
+	for _, item := range hub.GetInstalledByType(cwhub.SCENARIOS, true) {
+		if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
+			return fmt.Errorf("unable to download data for parser '%s': %+v", item.Name, err)
 		}
+
+		log.Debugf("scenario '%s' installed successfully in runtime environment", item.Name)
 	}
 
 	// install data for postoverflows if needed
-	ret = hub.GetItemMap(cwhub.POSTOVERFLOWS)
-	for postoverflowName, item := range ret {
-		if item.State.Installed {
-			if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
-				return fmt.Errorf("unable to download data for parser '%s': %+v", postoverflowName, err)
-			}
-
-			log.Debugf("postoverflow '%s' installed successfully in runtime environment", postoverflowName)
+	for _, item := range hub.GetInstalledByType(cwhub.POSTOVERFLOWS, true) {
+		if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
+			return fmt.Errorf("unable to download data for parser '%s': %+v", item.Name, err)
 		}
+
+		log.Debugf("postoverflow '%s' installed successfully in runtime environment", item.Name)
 	}
 
 	return nil

--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -66,21 +66,20 @@ func NewParsers(hub *cwhub.Hub) *Parsers {
 	}
 
 	for _, itemType := range []string{cwhub.PARSERS, cwhub.POSTOVERFLOWS} {
-		for _, hubParserItem := range hub.GetItemMap(itemType) {
-			if hubParserItem.State.Installed {
-				stagefile := Stagefile{
-					Filename: hubParserItem.State.LocalPath,
-					Stage:    hubParserItem.Stage,
-				}
-				if itemType == cwhub.PARSERS {
-					parsers.StageFiles = append(parsers.StageFiles, stagefile)
-				}
-				if itemType == cwhub.POSTOVERFLOWS {
-					parsers.PovfwStageFiles = append(parsers.PovfwStageFiles, stagefile)
-				}
+		for _, hubParserItem := range hub.GetInstalledByType(itemType, false) {
+			stagefile := Stagefile{
+				Filename: hubParserItem.State.LocalPath,
+				Stage:    hubParserItem.Stage,
+			}
+			if itemType == cwhub.PARSERS {
+				parsers.StageFiles = append(parsers.StageFiles, stagefile)
+			}
+			if itemType == cwhub.POSTOVERFLOWS {
+				parsers.PovfwStageFiles = append(parsers.PovfwStageFiles, stagefile)
 			}
 		}
 	}
+
 	if parsers.StageFiles != nil {
 		sort.Slice(parsers.StageFiles, func(i, j int) bool {
 			return parsers.StageFiles[i].Filename < parsers.StageFiles[j].Filename

--- a/test/bats/04_capi.bats
+++ b/test/bats/04_capi.bats
@@ -51,7 +51,7 @@ setup() {
     config_enable_capi
     rune -0 cscli capi register --schmilblick githubciXXXXXXXXXXXXXXXXXXXXXXXX
     rune -1 cscli capi status
-    assert_stderr --partial "no scenarios installed, abort"
+    assert_stderr --partial "no scenarios or appsec-rules installed, abort"
 
     rune -0 cscli scenarios install crowdsecurity/ssh-bf
     rune -0 cscli capi status


### PR DESCRIPTION
 - prefer higher level GetItemsByType, GetInstalledByType over GetItemMap
 - always send both appsec-rules and scenarios to api
 - explicit parameter for (case insensitive) sorted list of items
 - shorter code
 - assume itemType parameter makes sense, don't error